### PR TITLE
Update api_wrapper.py

### DIFF
--- a/src/rockstor/cli/api_wrapper.py
+++ b/src/rockstor/cli/api_wrapper.py
@@ -34,7 +34,7 @@ class APIWrapper(object):
         self.client_secret = client_secret
         # directly connect to gunicorn, bypassing nginx as we are on the same
         # host.
-        self.url = 'http://127.0.0.1:8000'
+        self.url = 'http://127.0.0.1:443'
         if (url is not None):
             # for remote urls.
             self.url = url


### PR DESCRIPTION
pass api calls through nginx to combat ulimit. See my comments in this thread: https://github.com/rockstor/rockstor-core/issues/1656 and https://forum.rockstor.com/t/exception-while-running-command-usr-bin-hostnamectl-static-errno-24-too-many-open-files/2272/5